### PR TITLE
Update Katex gem dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -52,7 +52,7 @@ spec = Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.required_ruby_version = '>= 2.3'
   s.add_dependency 'kramdown', '~> 2.0'
-  s.add_dependency 'katex', '~> 0.4.3'
+  s.add_dependency 'katex', '~> 0.5.0'
 
   s.has_rdoc = true
 

--- a/Rakefile
+++ b/Rakefile
@@ -52,7 +52,7 @@ spec = Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.required_ruby_version = '>= 2.3'
   s.add_dependency 'kramdown', '~> 2.0'
-  s.add_dependency 'katex', '~> 0.5.0'
+  s.add_dependency 'katex', '~> 0.4'
 
   s.has_rdoc = true
 


### PR DESCRIPTION
By the way, should this gem be so strict with the dependency?

I'd prefer '>= 0.5.0', as the ruby API isn't likely to change in a backwards-incompatible way ever but the version does get bumped with each new KaTeX release.